### PR TITLE
Fixed multi-language suppot

### DIFF
--- a/NSonic/Impl/Connections/SonicIngestConnection.cs
+++ b/NSonic/Impl/Connections/SonicIngestConnection.cs
@@ -77,7 +77,7 @@ namespace NSonic.Impl.Connections
                     , bucket
                     , @object
                     , $"\"{text}\""
-                    , !string.IsNullOrEmpty(locale) ? $"LOCALE({locale})" : ""
+                    , !string.IsNullOrEmpty(locale) ? $"LANG({locale})" : ""
                     );
             }
         }

--- a/NSonic/Impl/Connections/SonicSearchConnection.cs
+++ b/NSonic/Impl/Connections/SonicSearchConnection.cs
@@ -33,7 +33,7 @@ namespace NSonic.Impl.Connections
                     , $"\"{terms}\""
                     , limit.HasValue ? $"LIMIT({limit})" : ""
                     , offset.HasValue ? $"OFFSET({offset})" : ""
-                    , !string.IsNullOrEmpty(locale) ? $"LOCALE({locale})" : ""
+                    , !string.IsNullOrEmpty(locale) ? $"LANG({locale})" : ""
                     );
 
                 var response = session.Read();


### PR DESCRIPTION
Sonic uses `LANG` keyword instead of `LOCALE` to define locale. This PR fixes that issue.

Please check out [PROTOCOL.md](https://github.com/valeriansaliou/sonic/blob/master/PROTOCOL.md).