### PR TITLE
TcpClient's stream buffer will be lost when StreamReader is finalized.

### DIFF
--- a/NSonic/Impl/Session.cs
+++ b/NSonic/Impl/Session.cs
@@ -50,6 +50,11 @@ namespace NSonic.Impl
 
     class Session : ISession
     {
+
+        private StreamReader streamReader;
+
+        private StreamWriter streamWriter;
+
         public Session(IClient client)
         {
             this.Client = client;
@@ -59,31 +64,48 @@ namespace NSonic.Impl
 
         public void Dispose()
         {
-            //
         }
 
         public string Read()
         {
-            return new StreamReader(this.Client.GetStream()).ReadLine();
+            if (streamReader == null)
+            {
+                streamReader = new StreamReader(this.Client.GetStream());
+            }
+
+            return streamReader.ReadLine();
         }
 
         public async Task<string> ReadAsync()
         {
-            return await new StreamReader(await this.Client.GetStreamAsync()).ReadLineAsync();
+            if (streamReader == null)
+            {
+                streamReader = new StreamReader(await this.Client.GetStreamAsync());
+            }
+
+            return await streamReader.ReadLineAsync();
         }
 
         public void Write(params string[] args)
         {
-            var writer = new StreamWriter(this.Client.GetStream());
-            writer.WriteLine(this.CreateMessage(args));
-            writer.Flush();
+            if (streamWriter == null)
+            {
+                streamWriter = new StreamWriter(this.Client.GetStream());
+            }
+
+            streamWriter.WriteLine(this.CreateMessage(args));
+            streamWriter.Flush();
         }
 
         public async Task WriteAsync(params string[] args)
         {
-            var writer = new StreamWriter(await this.Client.GetStreamAsync());
-            await writer.WriteLineAsync(this.CreateMessage(args));
-            await writer.FlushAsync();
+            if (streamWriter == null)
+            {
+                streamWriter = new StreamWriter(await this.Client.GetStreamAsync());
+            }
+
+            await streamWriter.WriteLineAsync(this.CreateMessage(args));
+            await streamWriter.FlushAsync();
         }
 
         private string CreateMessage(string[] args)


### PR DESCRIPTION
When using QUERY, sonic server will send
`PENDING Bt2m2gYa\r\nEVENT QUERY Bt2m2gYa XXX\r\n`
Current behavior will lost second line and ReadLine() Method never returns.

```
Environment:
`.NET Core SDK（反映任何 global.json）:
 Version:   3.1.300
 Commit:    b2475c1295

运行时环境:
 OS Name:     Windows
 OS Version:  10.0.18362
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\3.1.300\

Host (useful for support):
  Version: 3.1.4
  Commit:  0c2e69caa6

sonic server: docker image, tag:v1.2.3
```