### PR TITLE
Add auto escaping in class PushRequest

### DIFF
--- a/NSonic.Tests/Connections/IngestConnectionTests.cs
+++ b/NSonic.Tests/Connections/IngestConnectionTests.cs
@@ -194,5 +194,97 @@ namespace NSonic.Tests.Connections
 
             this.VerifyAll();
         }
+
+        [TestMethod]
+        public async Task Push_ShouldBeAbleToPreventInjectionAttacksWithLocale_1() {
+            // Arrange
+
+            this.SetupWriteWithOk("PUSH", "collection_name", "bucket_name", "obj_id", "\"term\\\"\"", "LANG(test)");
+
+            // Act
+
+            if (this.Async) {
+                await this.connection.ConnectAsync();
+
+                await this.connection.PushAsync("collection_name", "bucket_name", "obj_id", "term\"", "test");
+            } else {
+                this.connection.Connect();
+
+                this.connection.Push("collection_name", "bucket_name", "obj_id", "term\"", "test");
+            }
+
+            // Assert
+
+            this.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task Push_ShouldBeAbleToPreventInjectionAttacksWithLocale_2() {
+            // Arrange
+
+            this.SetupWriteWithOk("PUSH", "collection_name", "bucket_name", "obj_id", "\"term\\n\"", "LANG(test)");
+
+            // Act
+
+            if (this.Async) {
+                await this.connection.ConnectAsync();
+
+                await this.connection.PushAsync("collection_name", "bucket_name", "obj_id", "term\n", "test");
+            } else {
+                this.connection.Connect();
+
+                this.connection.Push("collection_name", "bucket_name", "obj_id", "term\n", "test");
+            }
+
+            // Assert
+
+            this.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task Push_ShouldBeAbleToPreventInjectionAttacksWithoutLocale_1() {
+            // Arrange
+
+            this.SetupWriteWithOk("PUSH", "collection_name", "bucket_name", "obj_id", "\"term\\\"\"", "");
+
+            // Act
+
+            if (this.Async) {
+                await this.connection.ConnectAsync();
+
+                await this.connection.PushAsync("collection_name", "bucket_name", "obj_id", "term\"");
+            } else {
+                this.connection.Connect();
+
+                this.connection.Push("collection_name", "bucket_name", "obj_id", "term\"");
+            }
+
+            // Assert
+
+            this.VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task Push_ShouldBeAbleToPreventInjectionAttacksWithoutLocale_2() {
+            // Arrange
+
+            this.SetupWriteWithOk("PUSH", "collection_name", "bucket_name", "obj_id", "\"term\\n\"", "");
+
+            // Act
+
+            if (this.Async) {
+                await this.connection.ConnectAsync();
+
+                await this.connection.PushAsync("collection_name", "bucket_name", "obj_id", "term\n");
+            } else {
+                this.connection.Connect();
+
+                this.connection.Push("collection_name", "bucket_name", "obj_id", "term\n");
+            }
+
+            // Assert
+
+            this.VerifyAll();
+        }
     }
 }

--- a/NSonic/Impl/Connections/IngestConnection.cs
+++ b/NSonic/Impl/Connections/IngestConnection.cs
@@ -163,7 +163,7 @@ namespace NSonic.Impl.Connections
                 this.locale = locale;
             }
 
-            public string Text => $"\"{this.text}\"";
+            public string Text => $"\"{this.text.Replace("\n", " ").Replace("\"", "\\\"")}\"";
             public string Locale => !string.IsNullOrEmpty(this.locale) ? $"LANG({this.locale})" : "";
         }
     }

--- a/NSonic/Impl/Connections/IngestConnection.cs
+++ b/NSonic/Impl/Connections/IngestConnection.cs
@@ -163,7 +163,7 @@ namespace NSonic.Impl.Connections
                 this.locale = locale;
             }
 
-            public string Text => $"\"{this.text.Replace("\n", " ").Replace("\"", "\\\"")}\"";
+            public string Text => $"\"{this.text.Replace("\n", "\\n").Replace("\"", "\\\"")}\"";
             public string Locale => !string.IsNullOrEmpty(this.locale) ? $"LANG({this.locale})" : "";
         }
     }


### PR DESCRIPTION
I found that if I push a text like this: 
```
"" a
```

It will get an exception:
```
NSonic.AssertionException: Expected OK response : ERR invalid_meta_key(?[a"])
```

If I push a text like this:
```
a
a
```
It will get an exception:
```
NSonic.AssertionException: Expected OK response : ERR invalid_format(PUSH <collection> <bucket> <object> "<text>" [LANG(<locale>)]?)
```

I think it needs an auto escaping in NSonic.